### PR TITLE
Run instructions in the CPU

### DIFF
--- a/HDL/Icarus/bogus_hw.mem
+++ b/HDL/Icarus/bogus_hw.mem
@@ -1,0 +1,11 @@
+00        // NOP
+31 cc aa  // LD SP, $AACC
+21 80 de  // LD HL, $DE80
+3e bc     // LD A, $BC
+77        // LD (HL), A
+3e de     // LD A, $DE
+7e        // LD A, (HL)
+c3 12 01  // JP $0112
+
+@0112
+76        // HALT

--- a/HDL/Icarus/debuging_instructions.gtkw
+++ b/HDL/Icarus/debuging_instructions.gtkw
@@ -1,0 +1,118 @@
+[*]
+[*] GTKWave Analyzer v3.3.118 (w)1999-2023 BSI
+[*] Sun Mar 24 21:40:34 2024
+[*]
+[dumpfile] "/home/rodrigodd/repos/dmg-sim/dmgcpu/HDL/Icarus/dmg_waves.vcd"
+[dumpfile_mtime] "Sun Mar 24 21:29:41 2024"
+[dumpfile_size] 576665
+[savefile] "/home/rodrigodd/repos/dmg-sim/dmgcpu/HDL/Icarus/debuging_instructions.gtkw"
+[timestart] 3823
+[size] 1362 668
+[pos] -1 -1
+*-8.400001 5210 5210 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+[treeopen] SM83_Run.
+[treeopen] SM83_Run.dmgcore.
+[treeopen] SM83_Run.dmgcore.bot.
+[sst_width] 273
+[signals_width] 214
+[sst_expanded] 1
+[sst_vpaned_height] 180
+@28
+SM83_Run.clkgen.CLK
+SM83_Run.dmgcore.CLK9
+SM83_Run.dmgcore.dl.CLK
+@22
+SM83_Run.dmgcore.IR[7:0]
+SM83_Run.dmgcore.A[15:0]
+SM83_Run.dmgcore.D[7:0]
+SM83_Run.dmgcore.bot.pc.DL[7:0]
+@28
+SM83_Run.dmgcore.RD
+SM83_Run.dmgcore.WR
+@22
+SM83_Run.dmgcore.bot.pc.PC[15:0]
+SM83_Run.dmgcore.bot.sp.SP[15:0]
+SM83_Run.dmgcore.bot.regs.r1q[7:0]
+SM83_Run.dmgcore.bot.regs.r3q[7:0]
+SM83_Run.dmgcore.bot.regs.r2q[7:0]
+SM83_Run.dmgcore.dl.Res[7:0]
+@200
+-
+-databus to A
+@22
+SM83_Run.dmgcore.bot.IR[7:0]
+SM83_Run.dmgcore.D[7:0]
+SM83_Run.dmgcore.bot.DL[7:0]
+SM83_Run.dmgcore.bot.temp_regs.Z_in[7:0]
+SM83_Run.dmgcore.bot.zbus[7:0]
+SM83_Run.dmgcore.bot.bbus[7:0]
+SM83_Run.dmgcore.bot.bottom_left.bbq[7:0]
+@c00022
+SM83_Run.dmgcore.bot.DV[7:0]
+@28
+(0)SM83_Run.dmgcore.bot.DV[7:0]
+(1)SM83_Run.dmgcore.bot.DV[7:0]
+(2)SM83_Run.dmgcore.bot.DV[7:0]
+(3)SM83_Run.dmgcore.bot.DV[7:0]
+(4)SM83_Run.dmgcore.bot.DV[7:0]
+(5)SM83_Run.dmgcore.bot.DV[7:0]
+(6)SM83_Run.dmgcore.bot.DV[7:0]
+(7)SM83_Run.dmgcore.bot.DV[7:0]
+@1401200
+-group_end
+@22
+SM83_Run.dmgcore.bot.Res[7:0]
+SM83_Run.dmgcore.bot.fbus[7:0]
+SM83_Run.dmgcore.bot.regs.r1q[7:0]
+@28
+SM83_Run.dmgcore.bot.CLK2
+@200
+-
+-databus to HL
+@22
+SM83_Run.dmgcore.bot.IR[7:0]
+SM83_Run.dmgcore.D[7:0]
+SM83_Run.dmgcore.bot.DL[7:0]
+SM83_Run.dmgcore.bot.temp_regs.Z_in[7:0]
+SM83_Run.dmgcore.bot.temp_regs.W_in[7:0]
+SM83_Run.dmgcore.bot.zbus[7:0]
+SM83_Run.dmgcore.bot.wbus[7:0]
+SM83_Run.dmgcore.bot.ebus[7:0]
+SM83_Run.dmgcore.bot.fbus[7:0]
+SM83_Run.dmgcore.bot.regs.r2q[7:0]
+SM83_Run.dmgcore.bot.regs.r3q[7:0]
+@200
+-
+-databus to SP
+@22
+SM83_Run.dmgcore.bot.regs.IR[7:0]
+SM83_Run.dmgcore.D[7:0]
+SM83_Run.dmgcore.DL[7:0]
+SM83_Run.dmgcore.bot.temp_regs.Z_in[7:0]
+SM83_Run.dmgcore.bot.temp_regs.zbus[7:0]
+SM83_Run.dmgcore.bot.wbus[7:0]
+SM83_Run.dmgcore.bot.ebus[7:0]
+SM83_Run.dmgcore.bot.fbus[7:0]
+SM83_Run.dmgcore.bot.sp.sph_q[7:0]
+SM83_Run.dmgcore.bot.sp.spl_q[7:0]
+@200
+-
+-databus to PC
+@22
+SM83_Run.dmgcore.bot.regs.IR[7:0]
+SM83_Run.dmgcore.D[7:0]
+SM83_Run.dmgcore.DL[7:0]
+SM83_Run.dmgcore.bot.temp_regs.Z_in[7:0]
+SM83_Run.dmgcore.bot.temp_regs.zbus[7:0]
+SM83_Run.dmgcore.bot.wbus[7:0]
+SM83_Run.dmgcore.bot.pc.pcl_nd[7:0]
+SM83_Run.dmgcore.bot.pc.pch_nd[7:0]
+@23
+SM83_Run.dmgcore.bot.pc.pcl_q[7:0]
+@22
+SM83_Run.dmgcore.bot.pc.pch_q[7:0]
+@200
+-
+-
+[pattern_trace] 1
+[pattern_trace] 0

--- a/HDL/Icarus/run.v
+++ b/HDL/Icarus/run.v
@@ -119,8 +119,12 @@ module Bogus_HW ( MREQ, RD, WR, databus, addrbus );
 	inout [7:0] databus;
 	input [15:0] addrbus;
 
-	// Now the hardware is configured to give out single-byte opcodes for checking.
+	reg [7:0] mem[65535];
+	reg [7:0] value;
 
-	assign databus = (MREQ & RD) ? 8'b00111100 : 8'bzzzzzzzz;	// INC A (0x3c)
+	initial $readmemh("bogus_hw.mem", mem);
+
+	assign databus = (MREQ & RD) ? value : 8'bzzzzzzzz;
+	always @(addrbus) value <= mem[addrbus];
 
 endmodule // Bogus_HW

--- a/HDL/Regs.v
+++ b/HDL/Regs.v
@@ -99,8 +99,8 @@ module TempRegsBuses ( CLK4, CLK5, CLK6, d60, w, x, DL, bbus, cbus, dbus, ebus, 
 	assign ebus = ~(CLK4 ? ~(({8{`s3_oe_idu_to_uhlbus}}&adl) | ({8{`s3_oe_wzreg_to_uhlbus}}&zbus) | ({8{`s3_oe_ubus_to_uhlbus}}&Res)) : 8'b11111111);
 
 	assign d60w8 = ~(d60 | `s2_op_jr_any_sx01);
-	assign Z_in = ~(({8{d60}}&adl) | ({8{~d60}}&DL));
-	assign W_in = ~(({8{~d60w8}}&adh) | ({8{d60w8}}&DL));
+	assign Z_in = (({8{d60}}&adl) | ({8{~d60}}&DL));
+	assign W_in = (({8{~d60w8}}&adh) | ({8{d60w8}}&DL));
 
 endmodule // TempRegsBuses
 

--- a/HDL/Regs.v
+++ b/HDL/Regs.v
@@ -135,6 +135,10 @@ module SP ( CLK5, CLK6, CLK7, IR4, IR5, d60, d66, w, x, DL, abus, bbus, cbus, db
 	wire [7:0] spl_bnq;		// SPL input buskeeper output
 	wire [7:0] sph_bnq;		// SPH input buskeeper output
 
+	// For debugging purposes
+	wire [15:0] SP;
+	assign SP = {sph_q, spl_q};
+
 	sp_regbit SPL [7:0] ( .clk({8{CLK6}}), .cclk({8{CLK5}}), .nd(spl_bnq), .ld({8{`s3_wren_sp}}), .q(spl_q), .nq(spl_nq) );
 	sp_regbit SPH [7:0] ( .clk({8{CLK6}}), .cclk({8{CLK5}}), .nd(sph_bnq), .ld({8{`s3_wren_sp}}), .q(sph_q), .nq(sph_nq) );
 
@@ -189,6 +193,10 @@ module PC ( CLK5, CLK6, CLK7, d92, w, x, DL, abus, cbus, dbus, zbus, wbus, adl, 
 
 	wire [7:0] pcl_bnq;		// PCL input buskeeper output
 	wire [7:0] pch_bnq;		// PCH input buskeeper output
+
+	// For debugging purposes
+	wire [15:0] PC;
+	assign PC = {pch_q, pcl_q};
 
 	pc_regbit PCL [7:0] ( .clk({8{CLK6}}), .cclk({8{CLK5}}), .nres({8{~SYNC_RES}}), .nd(pcl_bnq), .ld({8{`s3_wren_pc}}), .q(pcl_q), .nq(pcl_nq) );
 	pc_regbit PCH [7:0] ( .clk({8{CLK6}}), .cclk({8{CLK5}}), .nres({8{~SYNC_RES}}), .nd(pch_bnq), .ld({8{`s3_wren_pc}}), .q(pch_q), .nq(pch_nq) );
@@ -273,7 +281,7 @@ module sp_regbit ( clk, cclk, nd, ld, q, nq );
 	assign q = ~val_out;
 	assign nq = ~q;
 
-endmodule // regbit
+endmodule // sp_regbit
 
 module pc_regbit ( clk, cclk, nd, ld, nres, q, nq );
 
@@ -307,4 +315,4 @@ module pc_regbit ( clk, cclk, nd, ld, nres, q, nq );
 	assign q = ~val_out;
 	assign nq = ~q;
 
-endmodule // regbit_res
+endmodule // pc_regbit

--- a/investigation.md
+++ b/investigation.md
@@ -1,0 +1,103 @@
+# JP a16 and LD SP, a16
+
+JP 0003 is writing 0xFFFC to PC instead of 0x0003, which is its inverse. The
+flow of 0x0003 to PC is inverted a couple of times, and one of them may be
+wrong.
+
+The flow is the following:
+
+pcq (FFFC) <- pc_bnq (0003) <- pcnd (0003) <- wzreg_to_pc ? zbus/wbus (FFFC) : IDU (N/A)
+
+I guess the flow between the "mux" and "pcq" is shared between the "IDU to PC"
+and this "ZREG to PC". And I guess that ZREG is shared with other instructions.
+So I am not sure where the problem is. I may need to test with other
+instructions first.
+
+Testing with the instruction "LD SP, 0003", the same problem happens, 0xFFFC is
+load into SP. This make thing that the problem is in zbus, as it is only used in
+PC and SP, as far as I know.
+
+~~Looking where zbus is first assigned, I found that all other bus are negations
+of zbus or wbus. This make me think that zbus should naturally be inverted, and
+the buses should directly connect to it.~~
+
+Actually, all registers are inverted, so maybe zbus should be inverted in its
+entired, as from my analysis below.
+
+# LD (HL), A (after `LD A, $BC` `LD HL, $ff80`)
+
+This should put A in the data bus, and HL in the address bus. But HL appear
+inverted (since the previous `LD HL, $ff80`) in the address bus, and the databus
+stays in high impedance.
+
+## Data bus stays in high impedance
+
+`DataLatch` is the only one connected to the external data bus `D`. Although it
+is called a "latch" it does not hold any data, it just forwards data from other
+data buses; that is `Res` (the result of the ALU) and `DL` (the internal
+databus).
+
+But `datalatch.md` states that it can only output values to `DL`, and load from
+either `D` or `Res`. But this should not be the case, because we need to output
+to the external bus, and `DataLatch` is the only one connected to it.
+
+Also, it specifies `DL` bus as `inout`, but never assign `z` to it. In fact,
+during the write (`WR` high) `DataBridge` also writes to `DL`, making `DL` go
+to invalid state `x`. Actually, a lot of things tries to write to `DL`.
+
+(Strangely, `DataBridge` only writes `0` or `z` bits to `DL`. Maybe `DL` has a
+pull-up somewhere? Oh, maybe that is what `BusPrecharge` does, not sure if
+verilog will simulate that. Oh, this is handle by the use of `BusKeeper`.)
+
+The value of register `A` is stored in `ReqA`/`r1q`, inverted. This value can be
+put in the `abus` or `bbus` (and `Aout`, but just affect ALU logic), but during
+write neither of them are used, `\`s2_op_alu8` (`w[3]`) and
+`\`s3_oe_areg_to_rbus` (`x[35]`) are both 0.
+
+## HL is inverted in the address bus
+
+`H` and `L` are stored in `ReqH`/`r3q` and `ReqL`/`r2q`, respectively, inverted.
+`H` can go to `abus`, `bbus` or `dbus`, and `L` can go to `abus`, `bbus` or
+`cbus`. They go to the bus through an inverter, so they have they original
+value.
+
+In this instruction, `H` goes to `dbus` and `L` goes to `cbus`. `dbus` `cbus` go
+through an `BusKeeper`, and them inverted again into the `AdressBus` (or `A`).
+
+From the comments in `IDU.v`, the code expects that the internal register
+actually holds the straight value of the ISA registers, but they are inverted in
+the current form. This was also seen in the `JP` instruction, and I fix that
+there by inverting the Zbus, but maybe we need to invert something more
+fundamental, like the value read from the memory?
+
+- H: `r3q` -> `dbus` -> `BusKeeper` -> `AddressBus` (inverted)
+- L: `r2q` -> `cbus` -> `BusKeeper` -> `AddressBus` (inverted)
+
+## Path from databus to register A
+
+- `D` -> `DataLatch` -> `DL` -> `Z_in` (inverted) -> `zbus` -> `bbus`
+  (straighted) -> `bbq` -> `DV` (inverted) -> `Res` -> `fbus` -> `RegA`
+
+So `RegA`/`r1q` contains the inverted value of `A`.
+
+## Path from databus to register HL
+
+- H: `D` -> `DataLatch` -> `DL` -> `W_in` (inverted) -> `wbus` -> `fbus` -> `RegH`
+- L: `D` -> `DataLatch` -> `DL` -> `Z_in` (inverted) -> `zbus` -> `ebus` -> `RegL`
+
+So `HL` are also stored inverted in the registers.
+
+## Path from databus to register SP
+
+- SP high: `D` -> `DataLatch` -> `DL` -> `W_in` (inverted) -> `wbus` -> `sph_nd` (inverted) -> `SPH` (inverted)
+- SP low:  `D` -> `DataLatch` -> `DL` -> `Z_in` (inverted) -> `zbus` -> `spl_nd` (inverted) -> `SPL` (inverted)
+
+So `SP` is also stored inverted in the registers.
+
+## Path from databus to PC
+
+
+- PC high: `D` -> `DataLatch` -> `DL` -> `W_in` (inverted) -> `wbus` -> `pch_nd` (inverted) -> `PCH` (inverted)
+- PC low:  `D` -> `DataLatch` -> `DL` -> `Z_in` (inverted) -> `zbus` -> `pcl_nd` (inverted) -> `PCL` (inverted)
+
+So `PC` is also stored inverted in the registers.


### PR DESCRIPTION
This PR contains my test setup for investigating problems in the execution of instruction in the CPU. My goal is to execute actual ROMs in the `dmg-sim` repo, but it is much faster to run simulations here.

For now ,it just adds some debug signals for PC and SP, and a read-only memory for `Bogus_HW`, but I expect to add read/write memory, and many more debug signals (at least for program visible state, like registers and interrupt signals) as things progress.

Currently, it is blocked by two major problems that I found, which I will create issues for.

This is the result of the simulation, with the issue about inverted registers fixed:

![image](https://github.com/emu-russia/dmgcpu/assets/51273772/c73ea9f5-8376-4287-bbc6-66e759c1f916)