### PR TITLE
Update Yosys/Verilator docs and add fix ADC instruction

### DIFF
--- a/HDL/sm83/ALU.v
+++ b/HDL/sm83/ALU.v
@@ -50,6 +50,9 @@ module ALU ( CLK2, CLK4, CLK5, CLK6, CLK7, DV, Res, AllZeros, d42, d58, w, x, bc
 	wire ALU_L5; 		// Carry4
 	wire ALU_to_bot;		// Derived from zbus[7] .  As a result of the optimization and transposition of the `bc` derivation circuit, the signal became internal.
 
+	// For debugging
+	(* keep *) wire [7:0] F = {bc[3], bc[2], bc[5], bc[1], 4'h0};
+
 	// Top part (CLA + Sum)
 
 	module6 Sums [7:0] (

--- a/HDL/sm83/ALU.v
+++ b/HDL/sm83/ALU.v
@@ -318,7 +318,7 @@ module LargeComb1 ( CLK2, CLK6, CLK7, Temp_Z, AllZeros, d42, d58, w, x, alu, IR,
 		(f[6]&`s2_cb_bit&nIR[3]&IR[4]&IR[5]) |
 		(f[7]&`s2_cb_bit&IR[3]&IR[4]&IR[5]) |
 		(AllZeros&(d42|`s2_op_alu8|`s2_op_incdec8|`s3_alu_daa)) | (d58&Temp_Z) | (bc[3]&(`s3_alu_cpl|`s2_op_add_hl_sxx0|`s3_alu_ccf_scf|`s2_op_add_hl_sx01)) );
-	assign az[13] = ~( `s3_alu_cp | (`s2_op_incdec8&nIR[0]) | (`s2_op_sp_e_sx10&bc[1]) | (`s3_alu_sub_sbc&(nIR[3]|nbc[1])) | (`s2_op_add_hl_sx01&bc[1]) | (`s3_alu_add_adc&IR[3]) );
+	assign az[13] = ~( `s3_alu_cp | (`s2_op_incdec8&nIR[0]) | (`s2_op_sp_e_sx10&bc[1]) | (`s3_alu_sub_sbc&(nIR[3]|nbc[1])) | (`s2_op_add_hl_sx01&bc[1]) | (`s3_alu_add_adc&IR[3]&bc[1]) );
 
 	// Dynamic part
 

--- a/HDL/sm83/Icarus/Makefile
+++ b/HDL/sm83/Icarus/Makefile
@@ -27,11 +27,6 @@ CYCLES=1024
 # Currently dmgcpu relies on a patched version of yosys.
 # Must be builded from source, from this branch: https://github.com/Rodrigodd/yosys/tree/dmgcpu-changes
 
-# DMG_YOSYS = /path/to/patched/yosys
-ifndef DMG_YOSYS
-$(error DMG_YOSYS is not set)
-endif
-
 run:
 	iverilog -Wall -D ICARUS -s SM83_Run -o sm83.run $(SOURCES) -DROM=\"$(ROM)\" -DWAVE_FILE=\"$(WAVE_FILE)\" -DCYCLES=$(CYCLES)
 	vvp sm83.run -fst
@@ -91,8 +86,12 @@ clean:
 	rm -f dmg_waves.fst
 	rm -f dmg_waves2.fst
 
+# DMG_YOSYS = /path/to/yosys-fork
 # Use yosys to optmize the code, and write back as verilog
 yosys: yosys.ys
+ifndef DMG_YOSYS
+	error DMG_YOSYS is not set
+endif
 	$(DMG_YOSYS) -s yosys.ys
 
 run_yosys:

--- a/HDL/sm83/Icarus/Readme.md
+++ b/HDL/sm83/Icarus/Readme.md
@@ -2,36 +2,41 @@
 
 Projects for Icarus Verilog (http://iverilog.icarus.com/).
 
-## How to use
+## How to Use
 
 - Download Icarus Verilog.
-- Run the simulation, using `make`:
+- Run the simulation using `make` (`ROM` can be any `.mem` file under `roms/`, `CYCLES` is the number of cycles to simulate):
 
 ```bash
-make run ROM=roms/cpu_instrs.mem # or any other .mem file in `roms`
+make run ROM=roms/cpu_instrs.mem CYCLES=1000000
 ```
 
-- Open `dmg_waves.fst` in GTKWave
-- Additionally, you can load prepared signal sets (debugging_instructions.gtkw) into GTKWave, File -> Read Save File
-- Think, scratch your head, fix bugs, redo everything
+- Open `dmg_waves.fst` in [GTKWave](https://gtkwave.sourceforge.net/) or [Surfer](https://surfer-project.org/).
+- Additionally, you can load prepared signal sets (`debugging_instructions.gtkw`) into GTKWave: File -> Read Save File.
+- Think, scratch your head, fix bugs, redo everything.
 
 ![dmg_waves](/imgstore/sm83/dmg_waves.png)
 
-# Verilator
+## Verilator
 
-> ⚠️ Verilator doesn't have enough support for high impedance signals, so this
-> simulation doesn't work correctly at all.
+The simulation can be run in [Verilator](https://www.veripool.org/verilator/), which is ~35x faster than Icarus Verilog, but it requires a bit more setup.
 
-The same simulation can be run in
-[verilator](https://www.veripool.org/verilator/) instead, which is much faster.
+First, you need a custom build of a fork of [Yosys](https://yosyshq.net/yosys/), found [on this branch](https://github.com/Rodrigodd/yosys/tree/dmgcpu-changes-2) (or [this commit, to be precise](https://github.com/Rodrigodd/yosys/commit/3ba9b002e5189a83ecfa4da7780d77eb4d2dfb70)). Yosys will be used to convert the current design, which uses high-impedance signals to simulate dynamic logic (unsuitable for simulation in Verilator), into a design that only uses `0` and `1` values and can be simulated with Verilator. For more details, see [this PR](https://github.com/emu-russia/dmgcpu/pull/292).
 
-To run the simulation, use `make`:
+Set the path to the Yosys binary using the `DMG_YOSYS` environment variable, and run Yosys with the `make` target `yosys`:
 
 ```bash
-make build run ROM=roms/cpu_instrs.mem # or any other .mem file in `roms`
+make yosys
 ```
 
-`build` will compile the verilog files to C++ and then to native, and `run` will
-run the compiled simulation.
+This will create a `sm83.yosys.v` file that can be used with Verilator (or any other simulator).
 
-This will generate a `dmg_waves.fst` file, which can be opened in GTKWave.
+Then, run the simulation with `make`:
+
+```bash
+make verilator ROM=roms/cpu_instrs.mem CYCLES=1000000
+```
+
+This will create a `dmg_waves3.fst` file that can be opened in [GTKWave](https://gtkwave.sourceforge.net/) or [Surfer](https://surfer-project.org/).
+
+Note that `sm83.yosys.v` flattens the entire design, so the hierarchy is lost, and many signals are removed. If you need a particular signal, add a `(* keep *)` attribute to it.

--- a/HDL/sm83/Icarus/roms/test_adc.mem
+++ b/HDL/sm83/Icarus/roms/test_adc.mem
@@ -1,0 +1,27 @@
+@0100  // .ORG   $100   
+00     // NOP   
+
+// for reference
+
+3E 1F  // LD   A,$1f   
+C6 01  // ADD  A,$1 // should result in $20
+
+// the actual tests
+
+3E 1F  // LD   A,$1f   
+B7     // OR   A    // clear all flags
+CE 01  // ADC  A,$1 // should result in $20
+
+3E 1F  // LD   A,$10   
+37     // SCF       // set carry
+CE 01  // ADC  A,$6 // should result in $21
+
+// check if zero is afecting the results
+
+AF     // XOR A     // set zero
+CE 01  // ADC  A,$1 // should result in $01
+
+3E 00  // LD   A,$0   
+B7     // OR   A    // set zero
+37     // SCF       // set zero and carry
+CE 01  // ADC  A,$1 // should result in $02

--- a/HDL/sm83/Icarus/yosys.ys
+++ b/HDL/sm83/Icarus/yosys.ys
@@ -81,7 +81,6 @@ chtype -map seq_dff_posedge_comp myseqdff
 setattr -mod -set keep_hierarchy 1 BusKeeper
 proc
 flatten
-opt_merge_wires SM83Core
 
 # find tribufs, and propragate them. The tribufs will propagate until they
 # reach a output port, a BusKeepr, or a internal bus. 
@@ -173,7 +172,6 @@ chtype -map BusKeeper mybuffer c:*perm_ff
 
 opt_clean SM83Core
 opt_merge
-opt_merge_wires
 
 # There now should be no BusKeeper
 cd SM83Core
@@ -184,7 +182,7 @@ cd
 tribuf -merge -logic 
 
 # A is a output port, but it does not need to be a tri-state buffer
-tribuf -merge -logic -force w:A %ci1
+tribuf -logic -force w:A %ci1
 
 # From this point onwards, the design should be completely synthesizable
 # (hopefully). So we can apply more aggressive optimizations.

--- a/HDL/sm83/Regs.v
+++ b/HDL/sm83/Regs.v
@@ -32,6 +32,16 @@ module RegsBuses ( CLK5, CLK6, w, x, DL, IR, abus, bbus, cbus, dbus, ebus, fbus,
 	wire [7:0] r6q;		// C
 	wire [7:0] r7q;		// B
 
+	// For debugging
+	(* keep *) wire [7:0] A = r1q;
+	(* keep *) wire [7:0] L = r2q;
+	(* keep *) wire [7:0] H = r3q;
+	(* keep *) wire [7:0] E = r4q;
+	(* keep *) wire [7:0] D = r5q;
+	(* keep *) wire [7:0] C = r6q;
+	(* keep *) wire [7:0] B = r7q;
+
+
 	regbit RegIR [7:0] ( .clk({8{CLK6}}), .cclk({8{CLK5}}), .d(DL), .ld({8{`s2_m1}}), .q(IR) );
 
 	regbit RegA [7:0] ( .clk({8{CLK6}}), .cclk({8{CLK5}}), .d(fbus), .ld({8{`s3_wren_a}}), .q(r1q) );
@@ -140,9 +150,8 @@ module SP ( CLK5, CLK6, CLK7, IR4, IR5, d60, d66, w, x, DL, abus, bbus, cbus, db
 	wire [7:0] spl_bnq;		// SPL input buskeeper output  (active low)
 	wire [7:0] sph_bnq;		// SPH input buskeeper output  (active low)
 
-	// For debugging purposes
-	wire [15:0] SP;
-	assign SP = {sph_q, spl_q};
+	// For debugging
+	(* keep *) wire [15:0] SP = {sph_q, spl_q};
 
 	sp_regbit SPL [7:0] ( .clk({8{CLK6}}), .cclk({8{CLK5}}), .nd(spl_bnq), .ld({8{`s3_wren_sp}}), .q(spl_q), .nq(spl_nq) );
 	sp_regbit SPH [7:0] ( .clk({8{CLK6}}), .cclk({8{CLK5}}), .nd(sph_bnq), .ld({8{`s3_wren_sp}}), .q(sph_q), .nq(sph_nq) );
@@ -199,9 +208,8 @@ module PC ( CLK5, CLK6, CLK7, d92, w, x, DL, abus, cbus, dbus, zbus, wbus, adl, 
 	wire [7:0] pcl_bnq;		// PCL input buskeeper output  (active low)
 	wire [7:0] pch_bnq;		// PCH input buskeeper output  (active low)
 
-	// For debugging purposes
-	wire [15:0] PC;
-	assign PC = {pch_q, pcl_q};
+	// For debugging
+	(* keep *) wire [15:0] PC = {pch_q, pcl_q};
 
 	pc_regbit PCL [7:0] ( .clk({8{CLK6}}), .cclk({8{CLK5}}), .nres({8{~SYNC_RES}}), .nd(pcl_bnq), .ld({8{`s3_wren_pc}}), .q(pcl_q), .nq(pcl_nq) );
 	pc_regbit PCH [7:0] ( .clk({8{CLK6}}), .cclk({8{CLK5}}), .nres({8{~SYNC_RES}}), .nd(pch_bnq), .ld({8{`s3_wren_pc}}), .q(pch_q), .nq(pch_nq) );

--- a/HDL/sm83/Seq.v
+++ b/HDL/sm83/Seq.v
@@ -12,7 +12,7 @@ module Sequencer ( CLK1, CLK2, CLK4, CLK6, CLK8, CLK9, nCLK4, IR, a, d, w, x, AL
 	input CLK9;
 	input nCLK4;
 
-	input [7:0] IR;
+	(* keep *) input [7:0] IR;
 	output [25:0] a;
 	input [106:0] d;
 	input [40:0] w;

--- a/HDL/sm83/Top.v
+++ b/HDL/sm83/Top.v
@@ -88,16 +88,16 @@ module SM83Core (
 	assign WR = `s2_wr;
 
 	// Debug wires:
-	// wire [15:0] RegPC = bot.pc.PC;
-	// wire [15:0] RegSP = bot.sp.SP;
-	// wire [7:0] RegA = bot.regs.r1q;
-	// wire [7:0] RegF = {alu_inst.bc[3], alu_inst.bc[2], alu_inst.bc[5], alu_inst.bc[1], 4'h0};
-	// wire [7:0] RegB = bot.regs.r7q;
-	// wire [7:0] RegC = bot.regs.r6q;
-	// wire [7:0] RegD = bot.regs.r5q;
-	// wire [7:0] RegE = bot.regs.r4q;
-	// wire [7:0] RegH = bot.regs.r3q;
-	// wire [7:0] RegL = bot.regs.r1q;
+	// (* keep *) wire [15:0] RegPC = bot.pc.PC;
+	// (* keep *) wire [15:0] RegSP = bot.sp.SP;
+	// (* keep *) wire [7:0] RegA = bot.regs.r1q;
+	// (* keep *) wire [7:0] RegF = {alu_inst.bc[3], alu_inst.bc[2], alu_inst.bc[5], alu_inst.bc[1], 4'h0};
+	// (* keep *) wire [7:0] RegB = bot.regs.r7q;
+	// (* keep *) wire [7:0] RegC = bot.regs.r6q;
+	// (* keep *) wire [7:0] RegD = bot.regs.r5q;
+	// (* keep *) wire [7:0] RegE = bot.regs.r4q;
+	// (* keep *) wire [7:0] RegH = bot.regs.r3q;
+	// (* keep *) wire [7:0] RegL = bot.regs.r1q;
 
 	// Instances
 

--- a/wiki/sm83/alu.md
+++ b/wiki/sm83/alu.md
@@ -220,7 +220,7 @@ Random logic (_14 NAND trees_):
 |alu_10|CLK2|e7|alu7 \| (w24&IR3&IR4&IR5) \| (w10&(nIR3\|nIR4\|nIR5)) \| (bc2&x22&(bc1\|bc5))|
 |alu_11|CLK6|ALU_Out1|w0 & ((nIR3&IR4&bc1) \| (IR3&IR4&~bc1) \| (IR3&nIR4&~bc3) \| (nIR3&nIR4&bc3))|
 |alu_12|CLK6|bc3|(f0&w12&nIR3&nIR4&nIR5) \| (f1&w12&IR3&nIR4&nIR5) \| (f2&w12&nIR3&IR4&nIR5) \| (f3&w12&IR3&IR4&nIR5) \| (f4&w12&nIR3&nIR4&IR5) \| (f5&w12&IR3&nIR4&IR5) \| (f6&w12&nIR3&IR4&IR5) \| (f7&w12&IR3&IR4&IR5) \| (AllZeros&(d42\|w3\|w37\|x22)) \| (d58&TempZ) \| (bc3&(x26\|w15\|x21\|w19))|
-|alu_13|CLK2|ALU_to_top ("Carry In")|x27 \| (w37&nIR0) \| (w9&bc1) \| (x24&(nIR3\|~bc1)) \| (w19&bc1) \| (x23&IR3)|
+|alu_13|CLK2|ALU_to_top ("Carry In")|x27 \| (w37&nIR0) \| (w9&bc1) \| (x24&(nIR3\|~bc1)) \| (w19&bc1) \| (x23&IR3&bc1)|
 
 The result is an AND-to-NOR tree (using alu_0 as an example):
 


### PR DESCRIPTION
Started comparing the simulation between dmgcpu and my Game Boy emulator. I am generating traces from my emulator, in [this branch](https://github.com/Rodrigodd/gameroy/tree/trace-vcd), and comparing them side by side with the Verilator simulation to see when they mismatch. It needs a little manual intervention to sync the two simulations, because the program tries to sync with v-blank using `LY` and on dmgcpu `LY` is always 0, but after that section of code, I can align them very well.

I noticed the first mismatch happens when executing the `ADC` instruction (add with carry). I created a test ROM, and I see that it is always adding 1, even if the carry bit is not set. Looking at the Verilog code and the topological map of the `LargeComp1`, I guessed we need to "and" ``(`s3_alu_add_adc&IR[3])`` with `bc[1]`.

But it is just a guess. I don't know how to read the topological map. Please confirm if that is the proper fix.