### PR TITLE
Fix DAA intructions

### DIFF
--- a/HDL/sm83/Bottom.v
+++ b/HDL/sm83/Bottom.v
@@ -198,9 +198,10 @@ module BottomLeftLogic ( CLK2, bc, bq4, bq5, bq7, Aout, abus, bbus, alu, DV );
 	wire [7:0] abq; 	// abus Bus keepers outputs
 	wire [7:0] bbq; 	// bbus Bus keepers outputs
 
-	assign bq4 = Aout[1] | Aout[2] | Aout[3];
-	assign bq5 = Aout[5] | Aout[6] | Aout[7];
-	assign bq7 = Aout[4] & Aout[7];
+	// Logic bits for DAA
+	assign bq4 = (Aout[1] | Aout[2]) & Aout[3]; // is the lower nibble greater than 9?
+	assign bq5 = (Aout[5] | Aout[6]) & Aout[7]; // is the upper nibble greater than 9?
+	assign bq7 = Aout[4] & Aout[7];             // are both nibbles greater than or equal to 8?
 	
 	// This requires transparent latches, since nobody could set up a abus/bbus. On the actual circuit, they are also present as a memory on the `not` gate.
 	BusKeeper abus_keepers [7:0] ( .d(abus), .q(abq) );

--- a/HDL/sm83/Icarus/roms/test_daa.mem
+++ b/HDL/sm83/Icarus/roms/test_daa.mem
@@ -1,0 +1,56 @@
+// DAA pseudo code:
+//
+//     if !N:
+//         if C or a > 0x99:
+//             a += 0x60
+//             C = 1
+//         if H or (a & 0x0F) > 0x09:
+//             a += 0x6;
+//     else
+//         if C:
+//             a -= 0x60
+//         if H:
+//             a -= 0x6;
+//     Z = (a == 0)
+//     H = 0
+
+@0100    // .ORG   $100   
+00       // NOP   
+
+31 00 E0 // LD SP, $E000
+
+01 00 01 // LD BC, $0100 
+C5       // PUSH BC     
+F1       // POP AF      // A=01; clear N, H, C
+00       // NOP         // NOPs to check for signals changes due to DAA, and not due the value of A changing
+00       // NOP
+27       // DAA         // A=01
+
+01 00 02 // LD BC, $0200 
+C5       // PUSH BC     
+F1       // POP AF      // A=02; clear N, H, C
+00       // NOP         // NOPs to check for signals changes due to DAA, and not due the value of A changing
+00       // NOP
+27       // DAA         // A=02
+
+01 00 06 // LD BC, $0600 
+C5       // PUSH BC     
+F1       // POP AF      // A=06; clear N, H, C
+00       // NOP         // NOPs to check for signals changes due to DAA, and not due the value of A changing
+00       // NOP
+27       // DAA         // A=06
+
+                        
+AF       // XOR A       // A=0; clear N, H, C
+27       // DAA         // A=0;
+                        
+37       // SCF         // set C
+27       // DAA         // A=60
+                        
+AF       // XOR A       // A=0; clear N, H, C
+3D       // DEC A       // A=ff; set N, H
+27       // DAA         // A=05
+                        
+AF       // XOR A       // A=0; clear N, H, C
+3E BB    // LD A, $BB  // A=BB
+27       // DAA         // A=21; set C


### PR DESCRIPTION
With this fix, the test `blargg/01-special.gb` now passes!

In #131 (and then copied at the bottom of [wiki/sm83/bottom.md](https://github.com/emu-russia/dmgcpu/blob/main/wiki/sm83/bottom.md)), it is explained that the `bq4`, `bq5`, and `bq6` signals are used for the DAA instruction, but their logic in the Verilog code (and in your pencil drawings) was wrong. By creating a Karnaugh map of the expected logic, I noticed that an OR was swapped with an AND.

After fixing that, the DAA instruction finally works. Since the last PR, I figured out how I am supposed to read the topological maps, but now I see that the ones in the LargeComb are much easier to read than the logic blocks everywhere else. So again, I am unable to check if this fix aligns with the actual traces.

I will continue testing the others blargg's individual CPU tests.