### PR TITLE
Fix load of IE registers (and load ROMs at runtime)

### DIFF
--- a/HDL/sm83/IDU.v
+++ b/HDL/sm83/IDU.v
@@ -39,7 +39,7 @@ module IncDec ( CLK4, TTB1, TTB2, TTB3, BUS_DISABLE, cbus, dbus, adl, adh, AddrB
 
 	// The AddrBus value is formed on the basis of the bus keeper values of the cbus/dbus.
 
-	assign AddrBus = ~BUS_DISABLE ? {~dbq,~cbq} : 16'hzz;
+	assign AddrBus = ~BUS_DISABLE ? {~dbq,~cbq} : 16'hzzzz;
 
 endmodule // IncDec
 

--- a/HDL/sm83/IRQ.v
+++ b/HDL/sm83/IRQ.v
@@ -37,7 +37,7 @@ module IRQ_Logic ( CLK3, CLK4, CLK5, CLK6, DL, RD, CPU_IRQ_ACK, CPU_IRQ_TRIG, br
 	// IE/IF
 	module7 IE [7:0] ( .clk({8{CLK6}}), .cclk({8{CLK5}}), .d(DL), .ld({8{Thingy_to_bot}}), .res({8{SYNC_RES}}), .q(ieq), .nq(ienq) );
 	module8 IF [7:0] ( .clk({8{CLK3}}), .cclk({8{CLK4}}), .d(~(ieq&CPU_IRQ_TRIG)), .q(ifq), .nq(ifnq) );
-	assign DL = (RD & bot_to_Thingy) ? ienq : 8'bzzzzzzzz; 	// znand3.
+	assign DL = (RD & bot_to_Thingy) ? ~ienq : 8'bzzzzzzzz; 	// znand3.
 
 	// Breadcrumps
 	assign nso = ~SeqOut_1;

--- a/HDL/sm83/Icarus/Makefile
+++ b/HDL/sm83/Icarus/Makefile
@@ -28,21 +28,18 @@ CYCLES=1024
 # Must be builded from source, from this branch: https://github.com/Rodrigodd/yosys/tree/dmgcpu-changes
 
 run:
-	iverilog -Wall -D ICARUS -s SM83_Run -o sm83.run $(SOURCES) "-DROM=\"$(ROM)\"" -DWAVE_FILE=\"$(WAVE_FILE)\" -DCYCLES=$(CYCLES)
-	vvp sm83.run -fst
+	iverilog -Wall -D ICARUS -s SM83_Run -o sm83.run $(SOURCES)
+	vvp sm83.run -fst "+ROM=$(ROM)" "+WAVE_FILE=$(WAVE_FILE)" "+CYCLES=$(CYCLES)"
 
 low:
-	/bin/iverilog -Wall -D ICARUS -s SM83_Run -o sm83.run $(SOURCES) "-DROM=\"$(ROM)\"" -DWAVE_FILE=\"$(WAVE_FILE)\" -DCYCLES=$(CYCLES)
-	/bin/vvp sm83.run -fst
+	/bin/iverilog -Wall -D ICARUS -s SM83_Run -o sm83.run $(SOURCES)
+	/bin/vvp sm83.run -fst "+ROM=$(ROM)" "+WAVE_FILE=$(WAVE_FILE)" "+CYCLES=$(CYCLES)"
 
 verbose:
-	iverilog -v -Wall -D ICARUS -s SM83_Run -o sm83.run $(SOURCES) "-DROM=\"$(ROM)\"" -DWAVE_FILE=\"$(WAVE_FILE)\" -DCYCLES=$(CYCLES)
-	vvp -v sm83.run -fst
+	iverilog -v -Wall -D ICARUS -s SM83_Run -o sm83.run $(SOURCES)
+	vvp -v sm83.run -fst "+ROM=$(ROM)" "+WAVE_FILE=$(WAVE_FILE)" "+CYCLES=$(CYCLES)"
 
 VERILATOR_OPTS=\
- "-DROM=\"$(ROM)\""\
- -DWAVE_FILE=\"dmg_waves3.fst\"\
- -DCYCLES=$(CYCLES)\
  --top-module SM83_Run\
  --cc\
  sm83.yosys.v\
@@ -58,21 +55,21 @@ VERILATOR_OPTS=\
 
 verilator:
 	verilator $(VERILATOR_OPTS) --binary -j 0 --Mdir verilator_build
-	verilator_build/VSM83_Run +verilator+rand+reset+1
+	verilator_build/VSM83_Run +verilator+rand+reset+1 "+ROM=$(ROM)" "+WAVE_FILE=$(WAVE_FILE)" "+CYCLES=$(CYCLES)"
 
 verilator-pgo:
-	verilator $(VERILATOR_OPTS) --binary -j 0 -CFLAGS -fprofile-generate -LDFLAGS -fprofile-generate -DCYCLES=1024 --Mdir verilator_pgo_build
-	verilator_pgo_build/VSM83_Run
+	verilator $(VERILATOR_OPTS) --binary -j 0 -CFLAGS -fprofile-generate -LDFLAGS -fprofile-generate --Mdir verilator_pgo_build
+	verilator_pgo_build/VSM83_Run "+ROM=$(ROM)" "+WAVE_FILE=$(WAVE_FILE)" "+CYCLES=10240"
 	verilator $(VERILATOR_OPTS) --binary -j 0 -CFLAGS "-fprofile-use -fprofile-correction" --Mdir verilator_pgo_build
-	verilator_pgo_build/VSM83_Run +verilator+rand+reset+1
+	verilator_pgo_build/VSM83_Run +verilator+rand+reset+1 "+ROM=$(ROM)" "+WAVE_FILE=$(WAVE_FILE)" "+CYCLES=$(CYCLES)"
 
 run_verilator:
 	# The Sequencer need that at least w83 to be initialized as 1, so we pass +rand+reset+1
-	verilator_build/VSM83_Run +verilator+rand+reset+1
+	verilator_build/VSM83_Run +verilator+rand+reset+1 "+ROM=$(ROM)" "+WAVE_FILE=$(WAVE_FILE)" "+CYCLES=$(CYCLES)"
 
 run_verilator_pgo:
 	# The Sequencer need that at least w83 to be initialized as 1, so we pass +rand+reset+1
-	verilator_pgo_build/VSM83_Run +verilator+rand+reset+1
+	verilator_pgo_build/VSM83_Run +verilator+rand+reset+1 "+ROM=$(ROM)" "+WAVE_FILE=$(WAVE_FILE)" "+CYCLES=$(CYCLES)"
 
 check:
 	verilator $(VERILATOR_OPTS) --lint-only --report-unoptflat
@@ -96,5 +93,5 @@ endif
 
 run_yosys:
 	echo "+timescale+1ns/1ns" > command_file.txt
-	iverilog -f command_file.txt -g2012 -Wall -D ICARUS -s SM83_Run -o sm83.yosys.run sm83.yosys.v external_clk.v run.v "-DROM=\"$(ROM)\"" -DWAVE_FILE=\"dmg_waves2.fst\" -DCYCLES=$(CYCLES)
-	vvp sm83.yosys.run -fst
+	iverilog -f command_file.txt -g2012 -Wall -D ICARUS -s SM83_Run -o sm83.yosys.run sm83.yosys.v external_clk.v run.v
+	vvp sm83.yosys.run -fst "+ROM=$(ROM)" "+WAVE_FILE=$(WAVE_FILE)" "+CYCLES=$(CYCLES)"

--- a/HDL/sm83/Icarus/Readme.md
+++ b/HDL/sm83/Icarus/Readme.md
@@ -41,8 +41,6 @@ This will create a `dmg_waves3.fst` file that can be opened in [GTKWave](https:/
 
 Note that `sm83.yosys.v` flattens the entire design, so the hierarchy is lost, and many signals are removed. If you need a particular signal, add a `(* keep *)` attribute to it.
 
-Here's the corrected version of your text with typos and grammatical errors fixed:
-
 ## Testing
 
 The CPU is tested by running individual test ROMs from blargg's [cpu_instrs](https://github.com/retrio/gb-test-roms/tree/master/cpu_instrs) test suite (as well as the single ROM version). These ROMs rely very little on other peripherals of the GameBoy besides the CPU core itself. The necessary peripherals are emulated in the module `Bogus_HW` in `run.v`.

--- a/HDL/sm83/Icarus/roms/test_ld_ie.mem
+++ b/HDL/sm83/Icarus/roms/test_ld_ie.mem
@@ -1,0 +1,9 @@
+@0100  // .ORG   $100   
+00     // NOP   
+
+3E aa  // LD   A,$aa   
+e0 ff  // LDH  [$ff],A
+f0 ff  // LDH  A,[$ff]
+e0 ff  // LDH  [$ff],A
+f0 ff  // LDH  A,[$ff]
+e0 ff  // LDH  [$ff],A

--- a/HDL/sm83/Top.v
+++ b/HDL/sm83/Top.v
@@ -115,7 +115,8 @@ module SM83Core (
 		.DataOut(`s3_oe_rbus_to_pbus),
 		.DV(DV),
 		.RD_hack(RD),
-		.WR_hack(WR) );
+		.WR_hack(WR),
+		.bot_to_Thingy_hack(bot_to_Thingy) );
 
 	Decoder1 dec1 (
 		.CLK2(CLK2),


### PR DESCRIPTION
I have spent a couple of months trying to get [dmg-sim](https://github.com/msinger/dmg-sim) to run under Verilator, but I didn't get too far (working with SystemVerilog is quite trickier than with just Verilog). So I decided to just emulate using Icarus Verilog, normally. The simulation is quite slow, emulating 60s took 31h28min, around 31.5 minutes per emulated second on my current machine. For reference, emulating just the dmgcpu runs at around 32min/s (slower probably due to running a different load) and with Verilator it takes only 29.8 *seconds* per emulated second (~63 times faster).

Emulating the first seconds of "The Legend of Zelda, A Link to the Past" discovered a problem with loading IE registers.

One was a conflict in DataMux due to reading the IE register into the internal bus DL, while the RD signal was high making it also read from the external bus. I fixed that by introducing another hack signal in the DataMux, I suppose the conflict would not happen in a more precise emulation of the DataMux.

The second one which I would like you to confirm is that reads from the IE registers were being inverted. I just inverted `ienq` before assigning it to `DL`, not sure if that is where the fix must be placed.

With those fixed, I could emulate Zelda successfully, using `dmgcpu` as the core implementation (cc @msinger):

https://github.com/user-attachments/assets/3524ce8f-4c82-40e3-b815-640e50caf570

Next, I will see if I can run a couple of tests. Maybe some interrupt tests from [mooney test suite](https://github.com/Gekkio/mooneye-test-suite), or some PPU tests from [mealybug test roms](https://github.com/mattcurrie/mealybug-tearoom-tests).

I see you are making your own simulation of the dmg-cpu SoC on this repo, I will probably wait for that before attempting a Verilator simulation again, it will probably be easier to get it working.