### PR TITLE
Add BusKeeper to internal bus DL and only drive 0's in DataMux

### DIFF
--- a/HDL/sm83/Bottom.v
+++ b/HDL/sm83/Bottom.v
@@ -52,6 +52,9 @@ module Bottom ( CLK2, CLK4, CLK5, CLK6, CLK7, DL, DV, bc, bq4, bq5, bq7, Temp_C,
 
 	// Implementation
 
+	wire [7:0] DLq;
+	BusKeeper DL_latch [7:0] (.d(DL), .q(DLq));
+
 	BusPrecharge precharge (
 		.CLK2(CLK2),
 		.DL(DL),
@@ -77,7 +80,7 @@ module Bottom ( CLK2, CLK4, CLK5, CLK6, CLK7, DL, DV, bc, bq4, bq5, bq7, Temp_C,
 		.CLK6(CLK6),
 		.w(w),
 		.x(x),
-		.DL(DL),
+		.DL(DLq),
 		.IR(IR),
 		.abus(abus),
 		.bbus(bbus),
@@ -94,7 +97,7 @@ module Bottom ( CLK2, CLK4, CLK5, CLK6, CLK7, DL, DV, bc, bq4, bq5, bq7, Temp_C,
 		.d60(`s1_op_ld_nn_sp_s010),
 		.w(w),
 		.x(x),
-		.DL(DL),
+		.DL(DLq),
 		.bbus(bbus),
 		.cbus(cbus),
 		.dbus(dbus),

--- a/HDL/sm83/DataMux.v
+++ b/HDL/sm83/DataMux.v
@@ -94,17 +94,20 @@ module data_mux_bit ( clk, Test1, Res_to_DL, Res, Int_bus, Ext_bus, DataOut, dv_
 
 	assign Ext_bus = ~clk ? 1'b1
 			: RD_hack && ~WR_hack ? 1'bz
-			: ~RD_hack && WR_hack ? int_to_ext_q
+			: ~RD_hack && WR_hack && ~int_to_ext_q ? 1'b0
+			// the branch below should be z, but due to limitations on how
+			// Verilator is currently used, we cannot simulate the buskeeper
+			// in the D bus.
 			: 1'b1;
 
 	// don't read from D if also reading from IE
 	wire IntRD_hack = RD_hack && !bot_to_Thingy_hack;
 
 	assign Int_bus = ~clk ? 1'b1
-			: Res_to_DL ? res_q
-			: IntRD_hack && ~WR_hack ? ext_to_int_q 
-			: ~IntRD_hack && WR_hack && DataOut ? dv_q
+			: Res_to_DL && ~res_q ? 1'b0
+			: IntRD_hack && ~WR_hack && ~ext_to_int_q ?  1'b0
+			: ~IntRD_hack && WR_hack && DataOut && !dv_q ? 1'b0
 			: ~IntRD_hack && WR_hack ? 1'bz
-			: 1'b1;
+			: 1'bz;
 
 endmodule // data_mux_bit

--- a/HDL/sm83/IRQ.v
+++ b/HDL/sm83/IRQ.v
@@ -34,8 +34,11 @@ module IRQ_Logic ( CLK3, CLK4, CLK5, CLK6, DL, RD, CPU_IRQ_ACK, CPU_IRQ_TRIG, br
 	wire [7:0] ifnq; 	// IF output (complement)
 	wire [7:0] ack; 	// Acknowledged
 
+	wire [7:0] DLq;
+	BusKeeper  DL_latch [7:0] (.d(DL), .q(DLq));
+
 	// IE/IF
-	module7 IE [7:0] ( .clk({8{CLK6}}), .cclk({8{CLK5}}), .d(DL), .ld({8{Thingy_to_bot}}), .res({8{SYNC_RES}}), .q(ieq), .nq(ienq) );
+	module7 IE [7:0] ( .clk({8{CLK6}}), .cclk({8{CLK5}}), .d(DLq), .ld({8{Thingy_to_bot}}), .res({8{SYNC_RES}}), .q(ieq), .nq(ienq) );
 	module8 IF [7:0] ( .clk({8{CLK3}}), .cclk({8{CLK4}}), .d(~(ieq&CPU_IRQ_TRIG)), .q(ifq), .nq(ifnq) );
 	assign DL = (RD & bot_to_Thingy) ? ~ienq : 8'bzzzzzzzz; 	// znand3.
 

--- a/HDL/sm83/Icarus/roms/test_ld_stat.mem
+++ b/HDL/sm83/Icarus/roms/test_ld_stat.mem
@@ -1,0 +1,92 @@
+// Read STAT in a loop. The STAT register will eventually change during a
+// write, and the CPU will read the AND of all different values driven in the
+// bus.
+
+@0100     // .ORG   $100   
+00        // NOP   
+
+3E aa     // LD   A,$f0    // bit 8=1: PPU on (although Bogus_HW does not simulate that)
+e0 40     // LDH  [$40],A  // STAT <= A
+
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+f0 40     // LDH  A,[$40] // A <= STAT
+c3 05 01  // JP $0105

--- a/HDL/sm83/Icarus/yosys.ys
+++ b/HDL/sm83/Icarus/yosys.ys
@@ -18,13 +18,15 @@ read_verilog \
 
 hierarchy -top SM83Core
 
-write_rtlil sm83.1.rtlil
-
-# I don't remember exactly why these steps are necessary, but they are. If
-# these steps are not included, the BusKeeper inside DataMux is not removed in
-# later steps.
-flatten DataMux
+# In DataMux, the buskeepers res_latch and dv_latch are unecessary, as Res and
+# DV are never tristate, so we just flatten them as simple Buffers here. For
+# ext_to_int we do the same, but because we cannot optimize its BusKeeper, as
+# the `D` can be driven from outside the module. In that case we ensure in the
+# design that `D` is always driven.
 proc DataMux
+flatten data_mux_bit/c:res_latch data_mux_bit/c:dv_latch data_mux_bit/c:ext_to_int %%
+setattr -mod -set keep_hierarchy 1 BusKeeper
+flatten DataMux
 opt_clean -purge DataMux
 opt_clean RegsBuses
 
@@ -78,7 +80,6 @@ chtype -map seq_rs_latch2 mysr
 chtype -map seq_dff_posedge_comp myseqdff
 
 # avoid flattening BusKeeper, because it will be replaced by a $dlatch later on.
-setattr -mod -set keep_hierarchy 1 BusKeeper
 proc
 flatten
 
@@ -154,6 +155,10 @@ module mybuffer(input d, output q);
     assign q = d;
 endmodule
 EOT
+
+opt_clean SM83Core
+# Mege identical BusKeepers
+opt_merge -share_all SM83Core
 
 design -copy-to mybuskeepermap mybuskeeper
 design -copy-to mybuskeepermap8 mybuskeeper8


### PR DESCRIPTION
Fix #371. Also fix test mooneye's intr_2_mode3_timing test when running under `dmg-sim` (see https://github.com/msinger/dmg-sim/pull/4) (Cc @msinger).

In that test, the external bus signal changes while reading the PPU STAT memory mapped register. When this happens the value in the internal bus should be the AND of all signals driven into it. That's because the internal bus uses dynamic logic, so the bus is first pre-charged with high voltage, and later only zeros bits are driven into it. So if a bit in the external bus changes from 0 to 1, the bit in the internal bus should continue as zero.

This PR adds a test ROM that reads from the STAT register, and adds a very crude simulation of the STAT register in BogusHW.

This PR simulates the DL dynamic logic by only driving 0s after the pre-charging, and adding BusKeepers whenever the signals are read.

The same should have been done for the external bus D, but because of how the Verilator simulation is implemented that was not done. To optimize out the BusKeeper (and therefore make it compatible with Verilator) we need to analyze all tri-state signals driving it, which is not possible for the D bus as it is driven externally from the module. We could solve that in the future by making the yosys script that analyzes the module also read in the BogusHW module (a similar thing will be necessary when trying to simulate the rest of the GameBoy SoC in Verilator).

Here the wave of the test_ld_stat:

![image](https://github.com/user-attachments/assets/f6c42e82-e1ab-42bc-8834-48b70f6693a2)